### PR TITLE
Cleanup, refactoring, documentation

### DIFF
--- a/adapter/internal/egress/https.go
+++ b/adapter/internal/egress/https.go
@@ -38,6 +38,8 @@ func NewHTTPSWriter(
 
 	client := httpClient(dialTimeout, ioTimeout, skipCertVerify)
 
+	// metric-documentation-v2: (adapter.egress) Number of envelopes sent out
+	// to a syslog drain over https.
 	egressMetric := metricClient.NewCounterMetric("egress",
 		metricemitter.WithVersion(2, 0),
 		metricemitter.WithTags(map[string]string{"drain-protocol": "https"}),

--- a/adapter/internal/egress/syslog_connector.go
+++ b/adapter/internal/egress/syslog_connector.go
@@ -35,16 +35,22 @@ func NewSyslogConnector(
 	metricClient metricemitter.MetricClient,
 	opts ...ConnectorOption,
 ) *SyslogConnector {
+	// metric-documentation-v2: (adapter.dropped) Number of envelopes dropped
+	// when sending to a syslog drain over https.
 	httpsDroppedMetric := metricClient.NewCounterMetric("dropped",
 		metricemitter.WithVersion(2, 0),
 		metricemitter.WithTags(map[string]string{"drain-protocol": "https"}),
 	)
 
+	// metric-documentation-v2: (adapter.dropped) Number of envelopes dropped
+	// when sending to a syslog drain over syslog.
 	syslogDroppedMetric := metricClient.NewCounterMetric("dropped",
 		metricemitter.WithVersion(2, 0),
 		metricemitter.WithTags(map[string]string{"drain-protocol": "syslog"}),
 	)
 
+	// metric-documentation-v2: (adapter.dropped) Number of envelopes dropped
+	// when sending to a syslog drain over syslog-tls.
 	syslogTLSDroppedMetric := metricClient.NewCounterMetric("dropped",
 		metricemitter.WithVersion(2, 0),
 		metricemitter.WithTags(map[string]string{"drain-protocol": "syslog-tls"}),

--- a/adapter/internal/egress/tcp.go
+++ b/adapter/internal/egress/tcp.go
@@ -65,6 +65,8 @@ func NewTCPWriter(
 		scheme:    "syslog",
 	}
 
+	// metric-documentation-v2: (adapter.egress) Number of envelopes sent out
+	// to a syslog drain over syslog.
 	w.egressMetric = metricClient.NewCounterMetric(
 		"egress",
 		metricemitter.WithVersion(2, 0),

--- a/adapter/internal/egress/tls.go
+++ b/adapter/internal/egress/tls.go
@@ -47,6 +47,8 @@ func NewTLSWriter(
 		},
 	}
 
+	// metric-documentation-v2: (adapter.egress) Number of envelopes sent out
+	// to a syslog drain over syslog-tls.
 	w.egressMetric = metricClient.NewCounterMetric(
 		"egress",
 		metricemitter.WithVersion(2, 0),

--- a/scheduler/app/scheduler.go
+++ b/scheduler/app/scheduler.go
@@ -122,15 +122,10 @@ func (s *Scheduler) setupIngress() {
 	)
 
 	if s.enableOptIn {
-		fetcher = ingress.NewVersionFilter(
-			fetcher,
-		)
+		fetcher = ingress.NewVersionFilter(fetcher)
 	}
 
-	s.fetcher = ingress.NewBlacklistFilter(
-		s.blacklist,
-		fetcher,
-	)
+	s.fetcher = ingress.NewBlacklistFilter(s.blacklist, fetcher)
 }
 
 func (s *Scheduler) startEgress() {

--- a/scheduler/app/scheduler.go
+++ b/scheduler/app/scheduler.go
@@ -131,8 +131,8 @@ func (s *Scheduler) setupIngress() {
 func (s *Scheduler) startEgress() {
 	creds := credentials.NewTLS(s.adapterTLSConfig)
 
-	pool := egress.NewAdapterPool(s.adapterAddrs, grpc.WithTransportCredentials(creds))
-	s.adapterService = egress.NewAdapterService(pool, s.health)
+	pool := egress.NewAdapterPool(s.adapterAddrs, s.health, grpc.WithTransportCredentials(creds))
+	s.adapterService = egress.NewAdapterService(pool)
 	orchestrator := egress.NewOrchestrator(s.fetcher, s.adapterService, s.health, s.emitter)
 	go orchestrator.Run(s.interval)
 }

--- a/scheduler/internal/egress/adapter_pool.go
+++ b/scheduler/internal/egress/adapter_pool.go
@@ -10,7 +10,7 @@ import (
 
 type AdapterPool []v1.AdapterClient
 
-func NewAdapterPool(addrs []string, opts ...grpc.DialOption) AdapterPool {
+func NewAdapterPool(addrs []string, h HealthEmitter, opts ...grpc.DialOption) AdapterPool {
 	var pool AdapterPool
 
 	for _, addr := range addrs {
@@ -23,6 +23,10 @@ func NewAdapterPool(addrs []string, opts ...grpc.DialOption) AdapterPool {
 		c := v1.NewAdapterClient(conn)
 
 		pool = append(pool, c)
+	}
+
+	if h != nil {
+		h.SetCounter(map[string]int{"adapterCount": len(pool)})
 	}
 
 	return pool

--- a/scheduler/internal/egress/adapter_pool_test.go
+++ b/scheduler/internal/egress/adapter_pool_test.go
@@ -18,15 +18,28 @@ var _ = Describe("AdapterPool", func() {
 		addr, cleanup := startGRPCServer()
 		defer cleanup()
 
-		pool := egress.NewAdapterPool([]string{addr}, grpc.WithInsecure())
+		pool := egress.NewAdapterPool([]string{addr}, nil, grpc.WithInsecure())
+		Expect(pool).To(HaveLen(1))
 		client := pool[0]
 
 		_, err := client.ListBindings(context.Background(), &v1.ListBindingsRequest{})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("reports adapterCount health metric", func() {
+		addr, cleanup := startGRPCServer()
+		defer cleanup()
+
+		healthEmitter := &spyHealthEmitter{}
+		egress.NewAdapterPool([]string{addr}, healthEmitter, grpc.WithInsecure())
+		counters := healthEmitter.setCounterArg
+		Expect(counters).To(HaveLen(1))
+		Expect(counters["adapterCount"]).To(Equal(1))
+	})
+
 	It("returns a pool with a unconnected client", func() {
-		pool := egress.NewAdapterPool([]string{"0.0.0.0:1234"}, grpc.WithInsecure())
+		pool := egress.NewAdapterPool([]string{"0.0.0.0:1234"}, nil, grpc.WithInsecure())
+		Expect(pool).To(HaveLen(1))
 		client := pool[0]
 
 		_, err := client.ListBindings(context.Background(), &v1.ListBindingsRequest{})
@@ -37,35 +50,35 @@ var _ = Describe("AdapterPool", func() {
 		addr := "1.1.1.1"
 
 		It("returns on client when one is in the pool", func() {
-			pool := egress.NewAdapterPool([]string{addr}, grpc.WithInsecure())
+			pool := egress.NewAdapterPool([]string{addr}, nil, grpc.WithInsecure())
 			subset := pool.Subset(0, 1)
 
 			Expect(len(subset)).To(Equal(1))
 		})
 
 		It("returns two clients when two are in the pool", func() {
-			pool := egress.NewAdapterPool([]string{addr, addr}, grpc.WithInsecure())
+			pool := egress.NewAdapterPool([]string{addr, addr}, nil, grpc.WithInsecure())
 			subset := pool.Subset(0, 2)
 
 			Expect(len(subset)).To(Equal(2))
 		})
 
 		It("returns a subset of the pool when there are many", func() {
-			pool := egress.NewAdapterPool([]string{addr, addr, addr, addr}, grpc.WithInsecure())
+			pool := egress.NewAdapterPool([]string{addr, addr, addr, addr}, nil, grpc.WithInsecure())
 			subset := pool.Subset(1, 2)
 
 			Expect(len(subset)).To(Equal(2))
 		})
 
 		It("wraps back to the first index on overflow", func() {
-			pool := egress.NewAdapterPool([]string{addr, addr, addr}, grpc.WithInsecure())
+			pool := egress.NewAdapterPool([]string{addr, addr, addr}, nil, grpc.WithInsecure())
 			subset := pool.Subset(1, 3)
 
 			Expect(len(subset)).To(Equal(3))
 		})
 
 		It("returns all clients when more are requested than available", func() {
-			pool := egress.NewAdapterPool([]string{addr, addr}, grpc.WithInsecure())
+			pool := egress.NewAdapterPool([]string{addr, addr}, nil, grpc.WithInsecure())
 			subset := pool.Subset(0, 3)
 
 			Expect(len(subset)).To(Equal(2))
@@ -86,4 +99,12 @@ func startGRPCServer() (string, func()) {
 		grpcServer.Stop()
 		lis.Close()
 	}
+}
+
+type spyHealthEmitter struct {
+	setCounterArg map[string]int
+}
+
+func (s *spyHealthEmitter) SetCounter(m map[string]int) {
+	s.setCounterArg = m
 }

--- a/scheduler/internal/egress/adapter_service.go
+++ b/scheduler/internal/egress/adapter_service.go
@@ -96,7 +96,7 @@ func (d *DefaultAdapterService) DeleteDelta(actual ingress.Bindings, expected in
 
 // List returns a list of unique bindings per adapter. Duplicate bindings may
 // be returned because there may be multiple adapters with the same binding.
-func (d *DefaultAdapterService) List() (ingress.Bindings, error) {
+func (d *DefaultAdapterService) List() ingress.Bindings {
 	var allBindings ingress.Bindings
 	request := &v1.ListBindingsRequest{}
 
@@ -104,6 +104,7 @@ func (d *DefaultAdapterService) List() (ingress.Bindings, error) {
 		ctx, _ := context.WithTimeout(context.Background(), time.Second)
 		resp, err := client.ListBindings(ctx, request)
 		if err != nil {
+			log.Printf("unable to retrieve bindings: %s", err)
 			continue
 		}
 		bindings := make(map[v1.Binding]struct{})
@@ -117,5 +118,5 @@ func (d *DefaultAdapterService) List() (ingress.Bindings, error) {
 		}
 	}
 
-	return allBindings, nil
+	return allBindings
 }

--- a/scheduler/internal/egress/adapter_service.go
+++ b/scheduler/internal/egress/adapter_service.go
@@ -24,9 +24,7 @@ const maxWriteCount = 2
 
 // NewAdapterService returns a new DefaultAdapterService initialized with the
 // Adapter pool.
-func NewAdapterService(p AdapterPool, h HealthEmitter) *DefaultAdapterService {
-	h.SetCounter(map[string]int{"adapterCount": len(p)})
-
+func NewAdapterService(p AdapterPool) *DefaultAdapterService {
 	return &DefaultAdapterService{
 		pool: p,
 	}

--- a/scheduler/internal/egress/adapter_service_test.go
+++ b/scheduler/internal/egress/adapter_service_test.go
@@ -15,8 +15,7 @@ import (
 
 var _ = Describe("DefaultAdapterService", func() {
 	var (
-		binding       v1.Binding
-		healthEmitter *SpyHealthEmitter
+		binding v1.Binding
 	)
 
 	BeforeEach(func() {
@@ -25,12 +24,11 @@ var _ = Describe("DefaultAdapterService", func() {
 			Hostname: "org.space.app",
 			Drain:    "syslog://my-drain-url",
 		}
-		healthEmitter = &SpyHealthEmitter{}
 	})
 
 	It("makes a call to remove drain", func() {
 		client := &spyClient{}
-		s := egress.NewAdapterService(egress.AdapterPool{client}, healthEmitter)
+		s := egress.NewAdapterService(egress.AdapterPool{client})
 
 		actual := ingress.Bindings{binding}
 		expected := ingress.Bindings{}
@@ -48,7 +46,7 @@ var _ = Describe("DefaultAdapterService", func() {
 
 	It("remove drains on hostname rename", func() {
 		client := &spyClient{}
-		s := egress.NewAdapterService(egress.AdapterPool{client}, healthEmitter)
+		s := egress.NewAdapterService(egress.AdapterPool{client})
 
 		actual := ingress.Bindings{binding}
 		expected := ingress.Bindings{
@@ -94,7 +92,6 @@ var _ = Describe("DefaultAdapterService", func() {
 
 			s := egress.NewAdapterService(
 				egress.AdapterPool{clientA, clientB, clientC},
-				healthEmitter,
 			)
 
 			bindings := s.List()
@@ -109,7 +106,7 @@ var _ = Describe("DefaultAdapterService", func() {
 			client := &spyClient{}
 			client.listBindingsError = errors.New("list failed")
 
-			s := egress.NewAdapterService(egress.AdapterPool{client}, healthEmitter)
+			s := egress.NewAdapterService(egress.AdapterPool{client})
 
 			bindings := s.List()
 			Expect(len(bindings)).To(Equal(0))
@@ -126,7 +123,7 @@ var _ = Describe("DefaultAdapterService", func() {
 		Context("with a single client in the pool", func() {
 			It("creates the binding on the client", func() {
 				client := &spyClient{}
-				s := egress.NewAdapterService(egress.AdapterPool{client}, healthEmitter)
+				s := egress.NewAdapterService(egress.AdapterPool{client})
 
 				s.CreateDelta(ingress.Bindings{}, ingress.Bindings{appBinding})
 
@@ -142,7 +139,7 @@ var _ = Describe("DefaultAdapterService", func() {
 
 			It("does not create a second binding when the client already has the binding", func() {
 				client := &spyClient{}
-				s := egress.NewAdapterService(egress.AdapterPool{client}, healthEmitter)
+				s := egress.NewAdapterService(egress.AdapterPool{client})
 
 				actual := ingress.Bindings{
 					{
@@ -161,7 +158,7 @@ var _ = Describe("DefaultAdapterService", func() {
 		It("writes both gRPC servers with two clients", func() {
 			firstClient := &spyClient{}
 			secondClient := &spyClient{}
-			s := egress.NewAdapterService(egress.AdapterPool{firstClient, secondClient}, healthEmitter)
+			s := egress.NewAdapterService(egress.AdapterPool{firstClient, secondClient})
 
 			s.CreateDelta(ingress.Bindings{}, ingress.Bindings{appBinding})
 
@@ -171,7 +168,7 @@ var _ = Describe("DefaultAdapterService", func() {
 
 		It("writes only to two gRPC servers with many clients", func() {
 			clients := egress.AdapterPool{&spyClient{}, &spyClient{}, &spyClient{}}
-			s := egress.NewAdapterService(clients, healthEmitter)
+			s := egress.NewAdapterService(clients)
 
 			s.CreateDelta(ingress.Bindings{}, ingress.Bindings{appBinding})
 
@@ -186,7 +183,7 @@ var _ = Describe("DefaultAdapterService", func() {
 
 		It("writes to only one gRPC server when another already has the binding", func() {
 			clients := egress.AdapterPool{&spyClient{}, &spyClient{}, &spyClient{}}
-			s := egress.NewAdapterService(clients, healthEmitter)
+			s := egress.NewAdapterService(clients)
 
 			s.CreateDelta(ingress.Bindings{
 				{AppId: "app-id", Hostname: "org.space.app", Drain: "syslog://my-drain-url"},
@@ -208,7 +205,7 @@ var _ = Describe("DefaultAdapterService", func() {
 			}
 
 			clients := egress.AdapterPool{&spyClient{}, &spyClient{}}
-			s := egress.NewAdapterService(clients, healthEmitter)
+			s := egress.NewAdapterService(clients)
 
 			s.CreateDelta(
 				ingress.Bindings{},
@@ -240,7 +237,7 @@ var _ = Describe("DefaultAdapterService", func() {
 
 		It("creates a new drain on hostname rename", func() {
 			client := &spyClient{}
-			s := egress.NewAdapterService(egress.AdapterPool{client}, healthEmitter)
+			s := egress.NewAdapterService(egress.AdapterPool{client})
 
 			actual := ingress.Bindings{binding}
 			expected := ingress.Bindings{

--- a/scheduler/internal/egress/adapter_service_test.go
+++ b/scheduler/internal/egress/adapter_service_test.go
@@ -97,8 +97,7 @@ var _ = Describe("DefaultAdapterService", func() {
 				healthEmitter,
 			)
 
-			bindings, err := s.List()
-			Expect(err).ToNot(HaveOccurred())
+			bindings := s.List()
 
 			Expect(clientA.listCalled).To(BeTrue())
 			Expect(clientB.listCalled).To(BeTrue())
@@ -112,7 +111,7 @@ var _ = Describe("DefaultAdapterService", func() {
 
 			s := egress.NewAdapterService(egress.AdapterPool{client}, healthEmitter)
 
-			bindings, _ := s.List()
+			bindings := s.List()
 			Expect(len(bindings)).To(Equal(0))
 		})
 	})

--- a/scheduler/internal/egress/orchestrator.go
+++ b/scheduler/internal/egress/orchestrator.go
@@ -20,7 +20,7 @@ type HealthEmitter interface {
 type AdapterService interface {
 	CreateDelta(actual ingress.Bindings, expected ingress.Bindings)
 	DeleteDelta(actual ingress.Bindings, expected ingress.Bindings)
-	List() (ingress.Bindings, error)
+	List() ingress.Bindings
 }
 
 // Orchestrator manages writes to a number of adapters.
@@ -70,11 +70,7 @@ func (o *Orchestrator) Run(interval time.Duration) {
 
 		o.drainGauge.Set(int64(len(expected)))
 
-		actual, err := o.service.List()
-		if err != nil {
-			log.Printf("failed to get actual bindings: %s", err)
-			continue
-		}
+		actual := o.service.List()
 
 		o.service.DeleteDelta(actual, expected)
 		o.service.CreateDelta(actual, expected)

--- a/scheduler/internal/egress/orchestrator_test.go
+++ b/scheduler/internal/egress/orchestrator_test.go
@@ -71,23 +71,6 @@ var _ = Describe("Orchestrator", func() {
 		Consistently(adapterService.CreateDeltaCalled).Should(BeFalse())
 	})
 
-	It("does not write when list fails", func() {
-		reader := &SpyReader{}
-		adapterService := &SpyAdapterService{
-			Err: errors.New("an error"),
-		}
-
-		o := egress.NewOrchestrator(
-			reader,
-			adapterService,
-			healthEmitter,
-			metricEmitter,
-		)
-		go o.Run(time.Millisecond)
-
-		Consistently(adapterService.CreateDeltaCalled).Should(BeFalse())
-	})
-
 	It("emits a metric for the number of drains", func() {
 		reader := &SpyReader{
 			drains: ingress.Bindings{
@@ -153,15 +136,14 @@ type SpyHealthEmitter struct{}
 func (s *SpyHealthEmitter) SetCounter(_ map[string]int) {}
 
 type SpyAdapterService struct {
-	Err                                    error
 	mu                                     sync.Mutex
 	createDeltaActual, createDeltaExpected ingress.Bindings
 	deleteDeltaActual, deleteDeltaExpected ingress.Bindings
 	createDeltaCalled                      bool
 }
 
-func (s *SpyAdapterService) List() (ingress.Bindings, error) {
-	return nil, s.Err
+func (s *SpyAdapterService) List() ingress.Bindings {
+	return nil
 }
 
 func (s *SpyAdapterService) CreateDelta(actual ingress.Bindings, expected ingress.Bindings) {


### PR DESCRIPTION
I was working on the `AdapterService` recently and noticed that it needed a little bit of attention in the documentation area. However, as I started reviewing the `AdapterService`, I noticed a few other things that didn't make sense or needed some refactoring.

Summary:
- Added godoc explanation of the AdapterService.
- Removed unused/unnecessary error from List()
- Moves the HealthEmitter reporting the `adapterCount` to the more appropriate place -
 `AdapterPool`
- Adds metric documentation to adapter `egress` and `dropped` metrics.

I apologize for the large PR, but I suggest reviewing each separate commit. I'm happy to pair with whomever during their flex hour to help them through this PR.