### PR TITLE
Use InstanceId field vs source_instance tag for process ID

### DIFF
--- a/adapter/internal/egress/tcp.go
+++ b/adapter/internal/egress/tcp.go
@@ -103,7 +103,7 @@ func generateRFC5424Message(
 		AppName:   appID,
 		ProcessID: generateProcessID(
 			env.Tags["source_type"].GetText(),
-			env.Tags["source_instance"].GetText(),
+			env.InstanceId,
 		),
 		Message: appendNewline(removeNulls(env.GetLog().Payload)),
 	}

--- a/adapter/internal/egress/tcp_test.go
+++ b/adapter/internal/egress/tcp_test.go
@@ -201,11 +201,11 @@ var _ = Describe("TCPWriter", func() {
 func buildLogEnvelope(srcType, srcInstance, payload string, logType loggregator_v2.Log_Type) *loggregator_v2.Envelope {
 	return &loggregator_v2.Envelope{
 		Tags: map[string]*loggregator_v2.Value{
-			"source_type":     {&loggregator_v2.Value_Text{srcType}},
-			"source_instance": {&loggregator_v2.Value_Text{srcInstance}},
+			"source_type": {&loggregator_v2.Value_Text{srcType}},
 		},
-		Timestamp: 12345678,
-		SourceId:  "source-id",
+		InstanceId: srcInstance,
+		Timestamp:  12345678,
+		SourceId:   "source-id",
 		Message: &loggregator_v2.Envelope_Log{
 			Log: &loggregator_v2.Log{
 				Payload: []byte(payload),


### PR DESCRIPTION
I want a sanity check on this since I soloed on it. This goes with the changes in loggregator here: https://github.com/cloudfoundry/loggregator/pull/302

[#149329517]