### PR TITLE
Remove use of non batched receiver

### DIFF
--- a/adapter/app/adapter_test.go
+++ b/adapter/app/adapter_test.go
@@ -471,16 +471,8 @@ func (t *testEgressServer) addr() string {
 }
 
 func (t *testEgressServer) Receiver(r *v2.EgressRequest, server v2.Egress_ReceiverServer) error {
+	panic("not implemented")
 
-	for i := 0; ; i++ {
-		err := server.Send(buildLogEnvelope(int64(i)))
-		if err != nil {
-			// Subtract 1 due to the last one failing
-			atomic.StoreInt64(&t.lastIdx, int64(i-1))
-			return err
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
 	return nil
 }
 

--- a/adapter/internal/ingress/client_manager_test.go
+++ b/adapter/internal/ingress/client_manager_test.go
@@ -186,13 +186,6 @@ func (s *spyReceiver) Invalidate() {
 	s.invalid = true
 }
 
-func (s *spyReceiver) Receiver(
-	context.Context,
-	*v2.EgressRequest, ...grpc.CallOption,
-) (v2.Egress_ReceiverClient, error) {
-	return nil, nil
-}
-
 func (s *spyReceiver) BatchedReceiver(
 	context.Context,
 	*v2.EgressBatchRequest,

--- a/adapter/internal/ingress/connector.go
+++ b/adapter/internal/ingress/connector.go
@@ -31,12 +31,6 @@ type Connector struct {
 // LogsProviderClient describes the gRPC interface for communicating with
 // Loggregator.
 type LogsProviderClient interface {
-	Receiver(
-		ctx context.Context,
-		in *loggregator_v2.EgressRequest,
-		opts ...grpc.CallOption,
-	) (loggregator_v2.Egress_ReceiverClient, error)
-
 	BatchedReceiver(
 		ctx context.Context,
 		in *loggregator_v2.EgressBatchRequest,
@@ -108,14 +102,6 @@ func (v *ValidClient) Invalidate() {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	v.invalid = true
-}
-
-func (v *ValidClient) Receiver(
-	ctx context.Context,
-	in *loggregator_v2.EgressRequest,
-	opts ...grpc.CallOption,
-) (loggregator_v2.Egress_ReceiverClient, error) {
-	return v.client.Receiver(ctx, in, opts...)
 }
 
 func (v *ValidClient) BatchedReceiver(

--- a/adapter/internal/ingress/subscriber.go
+++ b/adapter/internal/ingress/subscriber.go
@@ -172,34 +172,6 @@ func (s *Subscriber) attemptConnectAndRead(ctx context.Context, binding *v1.Bind
 		if batchStatus.Code() == codes.ResourceExhausted {
 			return true
 		}
-
-		// NOTE Loggregator v93 added BatchedReceiver. Once we can be certain
-		// Loggregator is v93 or above in all deployments, the following failover
-		// code should be deleted.
-		if batchStatus.Code() == codes.Unimplemented {
-			receiver, err := client.Receiver(ctx, &v2.EgressRequest{
-				ShardId:          buildShardId(binding),
-				UsePreferredTags: true,
-				Selectors:        selectors,
-				LegacySelector:   selectors[0],
-			})
-			close(ready)
-			if err != nil {
-				client.Invalidate()
-				return true
-			}
-			defer receiver.CloseSend()
-
-			if err := s.readWriteLoop(binding.AppId, receiver, writer); err != nil {
-				client.Invalidate()
-				if loopStatus, ok := status.FromError(err); ok && (loopStatus.Code() == codes.Canceled || loopStatus.Code() == codes.Unavailable) {
-					return true
-				}
-				log.Printf("Subscriber read/write loop has unexpectedly closed: %s", err)
-			}
-
-			return true
-		}
 	}
 	close(ready)
 	if err != nil {

--- a/tools/fake_adapter/main.go
+++ b/tools/fake_adapter/main.go
@@ -39,19 +39,19 @@ func main() {
 	}
 
 	defer conn.Close()
-	req := &loggregator_v2.EgressRequest{
+	req := &loggregator_v2.EgressBatchRequest{
 		ShardId: "some-shard-id",
 	}
-	stream, err := c.Receiver(context.Background(), req)
+	stream, err := c.BatchedReceiver(context.Background(), req)
 	if err != nil {
 		log.Fatalf("did not establish stream: %s", err)
 	}
 
 	for {
-		env, err := stream.Recv()
+		batch, err := stream.Recv()
 		if err != nil {
 			log.Fatalf("error reading from stream: %s", err)
 		}
-		fmt.Printf("%#v\n", env)
+		fmt.Printf("%#v\n", batch)
 	}
 }

--- a/tools/fake_logs_provider/main.go
+++ b/tools/fake_logs_provider/main.go
@@ -144,19 +144,8 @@ func (t *testEgressServer) addr() string {
 	return t.addr_
 }
 
-func (t *testEgressServer) Receiver(r *loggregator_v2.EgressRequest, server loggregator_v2.Egress_ReceiverServer) error {
-	var i int
-	for {
-		e := buildEnvelope(i%2 == 0, r.GetLegacySelector().GetSourceId(), i)
-
-		log.Printf("sending envelope: %d", i)
-		if err := server.Send(e); err != nil {
-			return err
-		}
-		log.Printf("sent envelope: %d", i)
-		i++
-		time.Sleep(t.delay)
-	}
+func (t *testEgressServer) Receiver(*loggregator_v2.EgressRequest, loggregator_v2.Egress_ReceiverServer) error {
+	panic("not implemented")
 
 	return nil
 }


### PR DESCRIPTION
The `BatchedReceiver` API has been out log enough that we can now remove the fallback to the non batched `Receiver`.

Fixes #17 